### PR TITLE
Introduced Twig support

### DIFF
--- a/Tests/AsyncKernelFunctionalTest.php
+++ b/Tests/AsyncKernelFunctionalTest.php
@@ -89,6 +89,11 @@ abstract class AsyncKernelFunctionalTest extends BaseFunctionalTest
                 Controller::class.':getPromiseException',
                 'promise-exception',
             ],
+            [
+                '/simple-result',
+                Controller::class.':getSimpleResult',
+                'simple-result',
+            ],
         ];
 
         return new AsyncBaseKernel(

--- a/Tests/Controller.php
+++ b/Tests/Controller.php
@@ -65,4 +65,14 @@ class Controller
     {
         return new RejectedPromise(new Exception('E2'));
     }
+
+    /**
+     * Return array.
+     *
+     * @return array
+     */
+    public function getSimpleResult(): array
+    {
+        return ['a', 'b'];
+    }
 }

--- a/Tests/Listener.php
+++ b/Tests/Listener.php
@@ -17,8 +17,10 @@ namespace Symfony\Component\HttpKernel\Tests;
 
 use React\Promise\FulfilledPromise;
 use React\Promise\PromiseInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
 /**
@@ -85,7 +87,7 @@ class Listener
     {
         return (new FulfilledPromise())
             ->then(function () use ($event) {
-                $event->setResponse(new Response('EXC'));
+                $event->setResponse(new Response('EXC', 404));
             });
     }
 
@@ -123,5 +125,15 @@ class Listener
     public function handleGetResponsePromise3(GetResponseEvent $event)
     {
         $_GET['partial'] .= '3';
+    }
+
+    /**
+     * Handle view.
+     *
+     * @param GetResponseForControllerResultEvent $event
+     */
+    public function handleView(GetResponseForControllerResultEvent $event)
+    {
+        $event->setResponse(new JsonResponse($event->getControllerResult()));
     }
 }


### PR DESCRIPTION
- Async kernel now works with the event VIEW, where Twig is built on top of
- Fixed some minor problems

!! Important

- Symfony Kernel has a private method called ->varToString($response), used
  in this package. The method has been completely copy/pasted here. Bad solution,
  but necessary here